### PR TITLE
feat: Create onboarding screen

### DIFF
--- a/To Do List/Goal.swift
+++ b/To Do List/Goal.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+struct Goal: Identifiable, Codable {
+    let id: UUID
+    var title: String
+}

--- a/To Do List/OnboardingView.swift
+++ b/To Do List/OnboardingView.swift
@@ -1,0 +1,79 @@
+import SwiftUI
+
+struct OnboardingView: View {
+    @Binding var isOnboardingComplete: Bool
+    @State private var name = ""
+    @State private var goal1 = ""
+    @State private var goal2 = ""
+    @State private var goal3 = ""
+    @State private var currentStep = 0
+
+    var body: some View {
+        VStack {
+            if currentStep == 0 {
+                nameStep
+            } else {
+                goalsStep
+            }
+        }
+        .padding()
+    }
+
+    var nameStep: some View {
+        VStack {
+            Text("Welcome! What's your name?")
+                .font(.largeTitle)
+                .padding()
+            TextField("Your Name", text: $name)
+                .textFieldStyle(RoundedBorderTextFieldStyle())
+                .padding()
+            Button("Next") {
+                if !name.isEmpty {
+                    currentStep = 1
+                }
+            }
+            .padding()
+            .foregroundColor(.white)
+            .background(Color.blue)
+            .cornerRadius(10)
+        }
+    }
+
+    var goalsStep: some View {
+        VStack {
+            Text("What are your 3 biggest goals, \(name)?")
+                .font(.largeTitle)
+                .padding()
+            TextField("Goal 1", text: $goal1)
+                .textFieldStyle(RoundedBorderTextFieldStyle())
+                .padding(.horizontal)
+            TextField("Goal 2", text: $goal2)
+                .textFieldStyle(RoundedBorderTextFieldStyle())
+                .padding(.horizontal)
+            TextField("Goal 3", text: $goal3)
+                .textFieldStyle(RoundedBorderTextFieldStyle())
+                .padding(.horizontal)
+
+            Button("Done") {
+                // Save the data
+                saveOnboardingData()
+                isOnboardingComplete = false
+            }
+            .padding()
+            .foregroundColor(.white)
+            .background(Color.blue)
+            .cornerRadius(10)
+        }
+    }
+
+    func saveOnboardingData() {
+        let goals = [
+            Goal(id: UUID(), title: goal1),
+            Goal(id: UUID(), title: goal2),
+            Goal(id: UUID(), title: goal3)
+        ].filter { !$0.title.isEmpty }
+
+        let userData = UserData(name: name, goals: goals)
+        PersistenceManager.saveUserData(userData)
+    }
+}

--- a/To Do List/PersistenceManager.swift
+++ b/To Do List/PersistenceManager.swift
@@ -6,6 +6,11 @@ struct PersistenceManager {
         return documentsDirectory.appendingPathComponent("tasks.json")
     }
 
+    static private var userFileUrl: URL {
+        let documentsDirectory = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
+        return documentsDirectory.appendingPathComponent("userData.json")
+    }
+
     static func loadTasks() -> [Task] {
         if let data = try? Data(contentsOf: tasksFileUrl) {
             if let decodedTasks = try? JSONDecoder().decode([Task].self, from: data) {
@@ -19,5 +24,24 @@ struct PersistenceManager {
         if let encodedData = try? JSONEncoder().encode(tasks) {
             try? encodedData.write(to: tasksFileUrl)
         }
+    }
+
+    static func saveUserData(_ userData: UserData) {
+        if let encodedData = try? JSONEncoder().encode(userData) {
+            try? encodedData.write(to: userFileUrl)
+        }
+    }
+
+    static func loadUserData() -> UserData? {
+        if let data = try? Data(contentsOf: userFileUrl) {
+            if let decodedUserData = try? JSONDecoder().decode(UserData.self, from: data) {
+                return decodedUserData
+            }
+        }
+        return nil
+    }
+
+    static func isOnboardingComplete() -> Bool {
+        return FileManager.default.fileExists(atPath: userFileUrl.path)
     }
 }

--- a/To Do List/UserData.swift
+++ b/To Do List/UserData.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+struct UserData: Codable {
+    let name: String
+    let goals: [Goal]
+}


### PR DESCRIPTION
This commit introduces an onboarding screen for new users. The screen prompts the user for their name and their three main goals.

The changes include:
- A new `OnboardingView` to handle the user interaction.
- `Goal` and `UserData` data models.
- Updates to `PersistenceManager` to save and load user data.
- The `HubView` is updated to show the onboarding screen and display the user's goals.